### PR TITLE
feat(perp): configure spacing based on chain id

### DIFF
--- a/packages/aggregator/CHANGELOG.md
+++ b/packages/aggregator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @synfutures/sdks-aggregator
 
+## 1.0.21
+
+### Patch Changes
+
+- Adapt to base tick spacing
+- Updated dependencies
+    - @synfutures/sdks-perp@1.0.21
+
 ## 1.0.20
 
 ### Patch Changes

--- a/packages/aggregator/package.json
+++ b/packages/aggregator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@synfutures/sdks-aggregator",
-    "version": "1.0.20",
+    "version": "1.0.21",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {

--- a/packages/perp/CHANGELOG.md
+++ b/packages/perp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @synfutures/sdks-perp
 
+## 1.0.21
+
+### Patch Changes
+
+- Adapt to base tick spacing
+
 ## 1.0.20
 
 ### Patch Changes

--- a/packages/perp/package.json
+++ b/packages/perp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@synfutures/sdks-perp",
-    "version": "1.0.21-test-close.2",
+    "version": "1.0.21",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {

--- a/packages/perp/src/constants.ts
+++ b/packages/perp/src/constants.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from 'ethers';
+import { CHAIN_ID } from '@derivation-tech/context';
 import { RawAmm } from './types';
 
 export const WAD_DECIMALS = 18;
@@ -15,9 +16,16 @@ export const MIN_TICK = -322517;
 export const INT24_MIN = -8388608;
 export const INT24_MAX = 8388607;
 
-export const PEARL_SPACING = 1;
-export const ORDER_SPACING = PEARL_SPACING;
-export const RANGE_SPACING = PEARL_SPACING * 50;
+export let PEARL_SPACING = 1;
+export let ORDER_SPACING = PEARL_SPACING;
+export let RANGE_SPACING = PEARL_SPACING * 50;
+
+export function configureSpacing(chainId: number): void {
+    const spacing = chainId === CHAIN_ID.BASE ? 5 : 1;
+    PEARL_SPACING = spacing;
+    ORDER_SPACING = PEARL_SPACING;
+    RANGE_SPACING = PEARL_SPACING * 50;
+}
 
 export const RATIO_BASE = 10000;
 export const STABILITY_FEE_RATIO_BASE = 100;

--- a/packages/perp/src/constants.ts
+++ b/packages/perp/src/constants.ts
@@ -21,10 +21,12 @@ export let ORDER_SPACING = PEARL_SPACING;
 export let RANGE_SPACING = PEARL_SPACING * 50;
 
 export function configureSpacing(chainId: number): void {
-    const spacing = chainId === CHAIN_ID.BASE ? 5 : 1;
-    PEARL_SPACING = spacing;
-    ORDER_SPACING = PEARL_SPACING;
-    RANGE_SPACING = PEARL_SPACING * 50;
+    // Default spacing is 1 for other chains, except BASE.
+    if (chainId === CHAIN_ID.BASE) {
+        PEARL_SPACING = 5;
+        ORDER_SPACING = PEARL_SPACING;
+        RANGE_SPACING = PEARL_SPACING * 10;
+    }
 }
 
 export const RATIO_BASE = 10000;

--- a/packages/perp/src/perp.module.ts
+++ b/packages/perp/src/perp.module.ts
@@ -22,6 +22,7 @@ import {
 } from './modules';
 import { PerpInterface } from './perp.interface';
 import { SynFuturesV3Contracts } from './types';
+import { configureSpacing } from './constants';
 
 export interface PerpModuleOptions {
     basePath?: string;
@@ -62,6 +63,8 @@ export class PerpModule implements PerpInterface {
             ...defaultOptions,
             ...options,
         };
+
+        configureSpacing(context.chainId);
 
         this.config = new ConfigModule(context);
         this.gate = new GateModule(context);


### PR DESCRIPTION
Add chain-specific spacing configuration for BASE chain. Default spacing remains 1 for other chains.